### PR TITLE
Add extraVolumes to migration job.

### DIFF
--- a/charts/lakekeeper/ci/volume-values.yaml
+++ b/charts/lakekeeper/ci/volume-values.yaml
@@ -1,0 +1,9 @@
+helmWait: true
+catalog:
+  extraVolumes:
+    - name: iceberg-catalog
+      emptyDir: {}
+  extraVolumeMounts:
+    - name: iceberg-catalog
+      mountPath: /volume-mount-test
+      readOnly: false

--- a/charts/lakekeeper/templates/db-migration.yaml
+++ b/charts/lakekeeper/templates/db-migration.yaml
@@ -84,3 +84,7 @@ spec:
             - migrate
           resources:
             {{- toYaml .Values.catalog.resources | nindent 12 }}
+      {{- with .Values.catalog.extraVolumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}


### PR DESCRIPTION
Using `catalog.extraVolumes` and `catalog.extraVolumeMounts` would previously not work because only `volumeMounts` where added to the migration job, not `volumes`:

https://github.com/lakekeeper/lakekeeper-charts/blob/3cdab95/charts/lakekeeper/templates/_pods.tpl#L35-L38


