### PR TITLE
Update OAuth2 settings to work with 0.8.0 release

### DIFF
--- a/charts/lakekeeper/templates/config/secret-config-envs.yaml
+++ b/charts/lakekeeper/templates/config/secret-config-envs.yaml
@@ -52,9 +52,9 @@ data:
 
   # OPENID Auth Configs
   {{- if .Values.auth.oauth2.providerUri }}
-  ICEBERG_REST__OPENID_PROVIDER_URI: {{ .Values.auth.oauth2.providerUri | toString | b64enc | quote }}
+  LAKEKEEPER__OPENID_PROVIDER_URI: {{ .Values.auth.oauth2.providerUri | toString | b64enc | quote }}
   {{- if .Values.auth.oauth2.audience }}
-  ICEBERG_REST__OPENID_AUDIENCE: {{ .Values.auth.oauth2.audience | toString | b64enc | quote }}
+  LAKEKEEPER__OPENID_AUDIENCE: {{ .Values.auth.oauth2.audience | toString | b64enc | quote }}
   {{- end }}
   # .Values.auth.oauth2.additionalIssuers is a list.
   # If it is not empty, join the list with a comma and set the value to LAKEKEEPER__OPENID_ADDITIONAL_ISSUERS
@@ -78,6 +78,9 @@ data:
   {{- if .Values.auth.k8s.enabled }}
   LAKEKEEPER__ENABLE_KUBERNETES_AUTHENTICATION: {{ "true" | b64enc | quote }}
   {{- end }}
+  {{- if .Values.auth.k8s.legacyEnabled }}
+  LAKEKEEPER__KUBERNETES_AUTHENTICATION_ACCEPT_LEGACY_SERVICEACCOUNT: {{ "true" | b64enc | quote }}
+  {{- end }}  
 
   ICEBERG_REST__BASE_URI: {{ $webUrl | b64enc | quote }}
 

--- a/charts/lakekeeper/values.yaml
+++ b/charts/lakekeeper/values.yaml
@@ -473,6 +473,9 @@ auth:
     # This option is compatible with `auth.oauth2` - multiple IdPs (OIDC and Kubernetes)
     # can be enabled simultaneously.
     enabled: false
+    # -- If true, will set LAKEKEEPER__KUBERNETES_AUTHENTICATION_ACCEPT_LEGACY_SERVICEACCOUNT to true
+    # This option will allow accepting tokens with `iss` claim set to kubernetes/serviceaccount
+    legacyEnabled: false
     # -- If true and `auth.k8s.enabled` is true, a ClusterRoleBinding is created
     # that allows lakekeeper to introspect tokens.
     createClusterRoleBinding: true


### PR DESCRIPTION
## Scope
- Replaced legacy ICEBERG_REST__OPENID_PROVIDER_URI and ICEBERG_REST__OPENID_AUDIENCE with new settings defined in https://docs.lakekeeper.io/docs/nightly/configuration/#authentication
- Added support for enabling legacy k8s auth via helm