### PR TITLE
fix: incorrect variable in Helm templates (envFrom -> extraEnvFrom)

### DIFF
--- a/charts/lakekeeper/Changelog.md
+++ b/charts/lakekeeper/Changelog.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
+* Corrected Helm templates to use `.Values.catalog.extraEnvFrom` instead of the incorrect `.Values.catalog.envFrom`.
 
 ### Changed
 

--- a/charts/lakekeeper/templates/_pods.tpl
+++ b/charts/lakekeeper/templates/_pods.tpl
@@ -22,8 +22,8 @@ Wait for OpenFGA - source: https://github.com/openfga/helm-charts/blob/main/char
     {{- toYaml .Values.catalog.initContainers.checkDb.resources | nindent 4 }}
   envFrom:
     {{- include "iceberg-catalog.envFrom" . | indent 4 }}
-    {{- if .Values.catalog.envFrom -}}
-    {{- toYaml .Values.catalog.envFrom | nindent 4 }}
+    {{- if .Values.catalog.extraEnvFrom -}}
+    {{- toYaml .Values.catalog.extraEnvFrom | nindent 4 }}
     {{- end }}
   env:
     {{- include "iceberg-catalog.env" . | indent 4 }}

--- a/charts/lakekeeper/templates/catalog/catalog-deployment.yaml
+++ b/charts/lakekeeper/templates/catalog/catalog-deployment.yaml
@@ -75,8 +75,8 @@ spec:
             {{- include "iceberg-catalog.env" . | indent 12 }}
           envFrom:
             {{- include "iceberg-catalog.envFrom" . | indent 12 }}
-            {{- if .Values.catalog.envFrom -}}
-            {{- toYaml .Values.catalog.envFrom | nindent 12 }}
+            {{- if .Values.catalog.extraEnvFrom -}}
+            {{- toYaml .Values.catalog.extraEnvFrom | nindent 12 }}
             {{- end }}
           ports:
             - name: http

--- a/charts/lakekeeper/templates/db-migration.yaml
+++ b/charts/lakekeeper/templates/db-migration.yaml
@@ -71,8 +71,8 @@ spec:
             {{- include "iceberg-catalog.env" . | indent 12 }}
           envFrom:
             {{- include "iceberg-catalog.envFrom" . | indent 12 }}
-            {{- if .Values.catalog.envFrom -}}
-            {{- toYaml .Values.catalog.envFrom | nindent 12 }}
+            {{- if .Values.catalog.extraEnvFrom -}}
+            {{- toYaml .Values.catalog.extraEnvFrom | nindent 12 }}
             {{- end }}
           {{- if .Values.catalog.command }}
           command:


### PR DESCRIPTION
## Description
This PR fixes an inconsistency between the Helm templates and the `values.yaml` file.
In the templates, the variable `.Values.catalog.envFrom` was used, while the correct field defined in `values.yaml` is `.Values.catalog.extraEnvFrom`.

I have updated all occurrences of `.Values.catalog.envFrom` to `.Values.catalog.extraEnvFrom` to ensure consistency and avoid deployment issues.

## Main changes

- Updated Helm templates to use `.Values.catalog.extraEnvFrom`
- No other functional changes

## Impact

- Fixes environment variables loading in the charts
- No breaking changes expected if `.Values.catalog.extraEnvFrom` was already used

   
Related to #72 