### PR TITLE
Remove ICEBERG__BASE_URI default setting

### DIFF
--- a/charts/lakekeeper/Changelog.md
+++ b/charts/lakekeeper/Changelog.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Volume mounting in the database migration job pod
 
 ### Changed
+* ICEBERG__BASE_URI is no longer added to default configuration. This allows to utilize `x-forwarded-for/x-forwarded-host` headers to ensure clients retain the base url when interacting with the catalog. 
 
 ## [0.5.3] - 2025-05-03
 

--- a/charts/lakekeeper/Changelog.md
+++ b/charts/lakekeeper/Changelog.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Volume mounting in the database migration job pod
 
 ### Changed
-* ICEBERG__BASE_URI is no longer added to default configuration. This allows to utilize `x-forwarded-for/x-forwarded-host` headers to ensure clients retain the base url when interacting with the catalog. 
+* ICEBERG__BASE_URI is no longer added to a default configuration. This allows to utilize `x-forwarded-for/x-forwarded-host` headers to ensure clients retain the base url when interacting with the catalog. 
 
 ## [0.5.3] - 2025-05-03
 

--- a/charts/lakekeeper/templates/config/secret-config-envs.yaml
+++ b/charts/lakekeeper/templates/config/secret-config-envs.yaml
@@ -8,9 +8,6 @@
   {{- end }}
 {{- end }}
 
-{{/* Define $webUrl at the top level */}}
-{{- $webUrl := "" }}
-
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/lakekeeper/templates/config/secret-config-envs.yaml
+++ b/charts/lakekeeper/templates/config/secret-config-envs.yaml
@@ -11,15 +11,6 @@
 {{/* Define $webUrl at the top level */}}
 {{- $webUrl := "" }}
 
-{{/* If `catalog.config.ICEBERG_REST__BASE_URL` is specified, it takes precedence */}}
-{{- if .Values.catalog.config.ICEBERG_REST__BASE_URL }}
-  {{- $webUrl = .Values.catalog.config.ICEBERG_REST__BASE_URL }}
-{{- else if .Values.catalog.ingress.enabled }}
-  {{- $protocol := ternary "https" "http" .Values.catalog.ingress.tls.enabled }}
-  {{- $webUrl = printf "%s://%s%s" $protocol .Values.catalog.ingress.host (default "" .Values.catalog.ingress.path) }}
-{{- else }}
-  {{- $webUrl = printf "http://%s.%s.svc.%s:%d" (include "iceberg-catalog.fullname" .) (.Release.Namespace) (.Values.clusterDomain) (int .Values.catalog.service.externalPort) }}
-{{- end }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -81,8 +72,6 @@ data:
   {{- if .Values.auth.k8s.legacyEnabled }}
   LAKEKEEPER__KUBERNETES_AUTHENTICATION_ACCEPT_LEGACY_SERVICEACCOUNT: {{ "true" | b64enc | quote }}
   {{- end }}  
-
-  ICEBERG_REST__BASE_URI: {{ $webUrl | b64enc | quote }}
 
   # Secret store configs
   {{- if eq "postgres" (lower .Values.secretBackend.type) }}

--- a/charts/lakekeeper/values.yaml
+++ b/charts/lakekeeper/values.yaml
@@ -111,9 +111,9 @@ catalog:
   # ---- EXAMPLE ----
   # config:
   #   ICEBERG_REST__BASE_URI: "https://data.example.com"
-  #   You need to set ICEBERG_REST__BASE_URI if Lakekeeper is running behind a proxy that does not set x-forwarded-for / x-forwarded-host headers
+  #   You only need to set ICEBERG_REST__BASE_URI if Lakekeeper is running behind a proxy that does not set x-forwarded-for / x-forwarded-host headers
   #   or if you want to force the same base url for all Iceberg clients interacting with a catalog
-  #   For more information regarding request routing can be found here: https://docs.lakekeeper.io/docs/latest/configuration/?h=x+forwar
+  #   More information regarding request routing can be found here: https://docs.lakekeeper.io/docs/latest/configuration/?h=x+forwar
 
   # -- if we add the annotation: "cluster-autoscaler.kubernetes.io/safe-to-evict" = "true"
   safeToEvict: true

--- a/charts/lakekeeper/values.yaml
+++ b/charts/lakekeeper/values.yaml
@@ -114,6 +114,7 @@ catalog:
   #   You only need to set ICEBERG_REST__BASE_URI if Lakekeeper is running behind a proxy that does not set x-forwarded-for / x-forwarded-host headers
   #   or if you want to force the same base url for all Iceberg clients interacting with a catalog
   #   More information regarding request routing can be found here: https://docs.lakekeeper.io/docs/latest/configuration/?h=x+forwar
+  #   LAKEKEEPER__USE_X_FORWARDED_HEADERS can be set to `false` to disable usage for x-forwarded headers
 
   # -- if we add the annotation: "cluster-autoscaler.kubernetes.io/safe-to-evict" = "true"
   safeToEvict: true

--- a/charts/lakekeeper/values.yaml
+++ b/charts/lakekeeper/values.yaml
@@ -107,12 +107,13 @@ catalog:
   # Please check the documentation for the available options.
   # https://docs.lakekeeper.io/docs/nightly/configuration/
   # Configuration items are mounted as environment variables.
-  # ICEBERG_REST__BASE_URI is required if ingress is disabled - otherwise
-  # the catalog will only work inside the cluster.
   config: {}
   # ---- EXAMPLE ----
   # config:
   #   ICEBERG_REST__BASE_URI: "https://data.example.com"
+  #   You need to set ICEBERG_REST__BASE_URI if Lakekeeper is running behind a proxy that does not set x-forwarded-for / x-forwarded-host headers
+  #   or if you want to force the same base url for all Iceberg clients interacting with a catalog
+  #   For more information regarding request routing can be found here: https://docs.lakekeeper.io/docs/latest/configuration/?h=x+forwar
 
   # -- if we add the annotation: "cluster-autoscaler.kubernetes.io/safe-to-evict" = "true"
   safeToEvict: true


### PR DESCRIPTION
Based on the investigation that happened as a result of my initial question. Lakekeeper currently always returns its own service or LB url, if installed via helm, regardless of what URL was used by the client to access the catalog.

This essentially means support for [forwarded headers](https://docs.lakekeeper.io/docs/latest/configuration/?h=x+forwar) is disabled in helm deployments - while it works perfectly fine :)

Let's remove this setting and point users to the docs. They can always set the env var via `catalog.config.ICEBERG__BASE_URI`, if they feel the need to.