### PR TITLE
Add extraContainers to the deployment template

### DIFF
--- a/charts/lakekeeper/Changelog.md
+++ b/charts/lakekeeper/Changelog.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 * Volume mounting in the database migration job pod
+* Catalog extraContainers setting is taken into account
 
 ### Changed
 

--- a/charts/lakekeeper/templates/catalog/catalog-deployment.yaml
+++ b/charts/lakekeeper/templates/catalog/catalog-deployment.yaml
@@ -114,6 +114,9 @@ spec:
           volumeMounts:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+        {{- if .Values.catalog.extraContainers }}
+        {{- toYaml .Values.catalog.extraContainers | nindent 8 }}
+        {{- end }}
       {{- with .Values.catalog.extraVolumes }}
       volumes:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
Adds extraContainers (which are advertised in values.yaml) to the deployment template.

Tested by deploying to a cluster and observing an extra container.

https://github.com/lakekeeper/lakekeeper-charts/issues/82