### PR TITLE
Use correct appVersion and bump OpenFGA chart to 0.2.44

### DIFF
--- a/charts/lakekeeper/Chart.yaml
+++ b/charts/lakekeeper/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: lakekeeper
 description: Helm Chart for Lakekeeper - a rust native Iceberg Rest Catalog
-version: 0.8.0
-appVersion: 0.10.0
+version: 0.8.1
+appVersion: 0.10.2
 type: application
 home: https://github.com/lakekeeper/lakekeeper
 icon: https://raw.githubusercontent.com/lakekeeper/lakekeeper/refs/heads/main/site/docs/assets/bear.svg
@@ -22,7 +22,7 @@ dependencies:
     condition: postgresql.enabled
     alias: postgresql
   - name: openfga
-    version: 0.2.35
+    version: 0.2.44
     repository: https://openfga.github.io/helm-charts
     condition: internalOpenFGA
     alias: openfga

--- a/charts/lakekeeper/README.md.gotmpl
+++ b/charts/lakekeeper/README.md.gotmpl
@@ -6,13 +6,12 @@
 
 Please check our [Documentation](http://docs.lakekeeper.io), the [Lakekeeper Repository](https://github.com/lakekeeper/lakekeeper) and the [`values.yaml`](https://github.com/lakekeeper/lakekeeper-charts/blob/main/charts/lakekeeper/values.yaml) for more information.
 
-## ⚠️ Important Notice: Upcoming changes to Bitnami Postgres
-
-This chart currently relies on the Bitnami PostgreSQL Helm chart for database backend services for both Lakekeeper and OpenFGA. Due to the [Bitnami Secure Images initiative](https://news.broadcom.com/app-dev/broadcom-introduces-bitnami-secure-images-for-production-ready-containerized-applications), Bitnami is retaining only the `latest` tags for their publicly available images.
+Due to the [Bitnami Secure Images initiative](https://news.broadcom.com/app-dev/broadcom-introduces-bitnami-secure-images-for-production-ready-containerized-applications), Bitnami is retaining only the `latest` tags for their publicly available images.
+This chart currently relies on the groundhog2k PostgreSQL Helm chart for database backend services for both Lakekeeper and OpenFGA.
 
 **Upcoming changes:**
-- Version `0.7.1`: We transition from Bitnami images to self-hosted images on Quay.io to ensure deployment stability
-- Version `0.8.0`: We will completely migrate away from the Bitnami chart
+- Version `0.7.1`: We will transition from Bitnami images to self-hosted images on Quay.io to ensure deployment stability
+- Version `0.8.0`: Migrated away from the Bitnami chart
 
 **Important notes:**
 - No automatic migration will be provided by this chart

--- a/charts/lakekeeper/values.yaml
+++ b/charts/lakekeeper/values.yaml
@@ -442,8 +442,6 @@ postgresql:
       - ReadWriteOnce
     # -- the StorageClass used by the PVC
     className:
-    # -- the size of PVC to request
-    size: 5Gi
 
 externalDatabase:
   # -- the type of external database.


### PR DESCRIPTION
* document changes made in https://github.com/lakekeeper/lakekeeper-charts/pull/99
* bump openfga chart version to 0.2.44
* bump lekekeeper image tag to 0.10.2
* use correct value for appVersion

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated Lakekeeper chart/app version to 0.10.2.
  - Upgraded authorization dependency to the latest compatible release.
  - Aligned catalog container image tag to v0.10.2.

- Configuration
  - PostgreSQL storage settings no longer specify an explicit size; capacity is now determined by the selected storage class. Adjust your storage class or override values if a specific size is required.

- Reliability
  - Includes upstream stability and compatibility improvements from dependency updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->