### PR TITLE
fix: Release 0.10.1, OPA sidecar read-only rootfs, OpenFGA DNS resolution

### DIFF
--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -40,14 +40,22 @@ jobs:
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Check for any chart file changes
+        id: chart-files-changed
+        run: |
+          changed=$(git diff --name-only origin/${{ github.event.repository.default_branch }}...HEAD -- charts/)
+          if [[ -n "$changed" ]]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Run chart-testing (lint)
         if: steps.list-changed.outputs.changed == 'true'
         run: ct lint --target-branch ${{ github.event.repository.default_branch }} --check-version-increment=false
 
       - name: Create kind cluster
-        if: steps.list-changed.outputs.changed == 'true'
+        if: steps.chart-files-changed.outputs.changed == 'true'
         uses: helm/kind-action@v1.14.0
 
       - name: Run chart-testing (install)
-        if: steps.list-changed.outputs.changed == 'true'
-        run: ct install --target-branch ${{ github.event.repository.default_branch }} --helm-extra-set-args "--set lakekeeper.licenseKey=${{ secrets.LAKEKEEPER_PLUS_LICENSE_KEY }}"
+        if: steps.chart-files-changed.outputs.changed == 'true'
+        run: ct install --target-branch ${{ github.event.repository.default_branch }} --helm-extra-set-args "--set lakekeeper.licenseKey=${{ secrets.LAKEKEEPER_PLUS_LICENSE_KEY }} --all"

--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -58,4 +58,4 @@ jobs:
 
       - name: Run chart-testing (install)
         if: steps.chart-files-changed.outputs.changed == 'true'
-        run: ct install --target-branch ${{ github.event.repository.default_branch }} --helm-extra-set-args "--set lakekeeper.licenseKey=${{ secrets.LAKEKEEPER_PLUS_LICENSE_KEY }} --all"
+        run: ct install --all --target-branch ${{ github.event.repository.default_branch }} --helm-extra-set-args "--set lakekeeper.licenseKey=${{ secrets.LAKEKEEPER_PLUS_LICENSE_KEY }}"

--- a/charts/lakekeeper/Changelog.md
+++ b/charts/lakekeeper/Changelog.md
@@ -13,6 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+## [0.10.1] - 2026-04-05
+
+### Fixed
+* Fix OPA Bridge sidecar failing to start with OPA >= 1.13 due to read-only root filesystem in Chainguard base image
+* Fix internal OpenFGA endpoint DNS resolution on clusters with custom DNS search domains (use absolute FQDN)
+
+### Changed
+* Move OPA config mount from `/run/secrets` to `/etc/opa` to avoid conflict with `/var/run` symlink
+
 ## [0.10.0] - 2026-04-05
 
 ### Changed

--- a/charts/lakekeeper/Chart.yaml
+++ b/charts/lakekeeper/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: lakekeeper
 description: Helm Chart for Lakekeeper - a rust native Iceberg Rest Catalog
-version: 0.10.0
+version: 0.10.1
 appVersion: 0.12.0
 type: application
 home: https://github.com/lakekeeper/lakekeeper

--- a/charts/lakekeeper/templates/catalog/catalog-deployment.yaml
+++ b/charts/lakekeeper/templates/catalog/catalog-deployment.yaml
@@ -136,6 +136,7 @@ spec:
           securityContext:
             runAsUser: {{ .Values.OPABridge.image.uid }}
             runAsGroup: {{ .Values.OPABridge.image.gid }}
+            readOnlyRootFilesystem: false
           env:
             - name: TRINO_ALLOW_UNMANAGED_CATALOGS
               value: {{ .Values.OPABridge.allowUnmanagedCatalogs | quote }}
@@ -200,7 +201,7 @@ spec:
             - "--server"
             - "--ignore=.*" # exclude hidden dirs created by Kubernetes
             - "--addr=:8282"
-            - "--config-file=/run/secrets/opa-config.yaml"
+            - "--config-file=/etc/opa/opa-config.yaml"
           {{- range .Values.OPABridge.extraArgs }}
             - {{ . | quote }}
           {{- end }}
@@ -227,11 +228,13 @@ spec:
             {{- toYaml .Values.OPABridge.resources | nindent 12 }}
           volumeMounts:
             - name: opa-config
-              mountPath: /run/secrets
+              mountPath: /etc/opa
               readOnly: true
             - name: opa-policies
               mountPath: /policies
               readOnly: true
+            - name: opa-var-run
+              mountPath: /var/run/secrets
       {{- end }}
       {{- if .Values.catalog.extraContainers }}
       {{- toYaml .Values.catalog.extraContainers | nindent 8 }}
@@ -245,6 +248,8 @@ spec:
         - name: opa-policies
           configMap:
             name: {{ include "iceberg-catalog.fullname" . }}-opa-policies
+        - name: opa-var-run
+          emptyDir: {}
       {{- end }}
       {{- with .Values.catalog.extraVolumes }}
         {{- toYaml . | nindent 8 }}

--- a/charts/lakekeeper/templates/config/secret-config-envs.yaml
+++ b/charts/lakekeeper/templates/config/secret-config-envs.yaml
@@ -102,7 +102,7 @@ data:
   {{- if .Values.authz.openfga.endpoint }}
   LAKEKEEPER__OPENFGA__ENDPOINT: {{ .Values.authz.openfga.endpoint | toString | b64enc | quote }}
   {{- else if .Values.internalOpenFGA }}
-  LAKEKEEPER__OPENFGA__ENDPOINT: {{ printf "http://%s.%s.svc.%s:%d" (  include "iceberg-catalog.openfga.fullname" . ) (.Release.Namespace) (.Values.clusterDomain) (int (split ":" .Values.openfga.grpc.addr)._1) | b64enc | quote }}
+  LAKEKEEPER__OPENFGA__ENDPOINT: {{ printf "http://%s.%s.svc.%s.:%d" (  include "iceberg-catalog.openfga.fullname" . ) (.Release.Namespace) (.Values.clusterDomain) (int (split ":" .Values.openfga.grpc.addr)._1) | b64enc | quote }}
   {{- end }}
 
   {{- if .Values.authz.openfga.store }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved OPA Bridge sidecar startup failures with OPA ≥ 1.13 on Chainguard base images.
  * Fixed DNS resolution for internal OpenFGA endpoints on clusters with custom DNS search domains.
  * Updated OPA configuration mount path to avoid filesystem conflicts.

* **Chores**
  * Bumped Helm chart version to 0.10.1 and added corresponding changelog entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->