### PR TITLE
feat: allow templating of envFrom

### DIFF
--- a/charts/lakekeeper/templates/_helpers.tpl
+++ b/charts/lakekeeper/templates/_helpers.tpl
@@ -295,7 +295,7 @@ The list of `env` catalog Pods
 
 {{- /* user-defined environment variables */ -}}
 {{- if .Values.catalog.extraEnv }}
-{{ toYaml .Values.catalog.extraEnv }}
+{{ tpl (toYaml .Values.catalog.extraEnv) . }}
 {{- end }}
 
 - name: LAKEKEEPER__PLACEHOLDER

--- a/charts/lakekeeper/templates/_pods.tpl
+++ b/charts/lakekeeper/templates/_pods.tpl
@@ -23,7 +23,7 @@ Wait for OpenFGA - source: https://github.com/openfga/helm-charts/blob/main/char
   envFrom:
     {{- include "iceberg-catalog.envFrom" . | indent 4 }}
     {{- if .Values.catalog.extraEnvFrom -}}
-    {{- toYaml .Values.catalog.extraEnvFrom | nindent 4 }}
+    {{- tpl (toYaml .Values.catalog.extraEnvFrom) . | nindent 4 }}
     {{- end }}
   env:
     {{- include "iceberg-catalog.env" . | indent 4 }}

--- a/charts/lakekeeper/templates/catalog/catalog-deployment.yaml
+++ b/charts/lakekeeper/templates/catalog/catalog-deployment.yaml
@@ -88,7 +88,7 @@ spec:
           envFrom:
             {{- include "iceberg-catalog.envFrom" . | indent 12 }}
             {{- if .Values.catalog.extraEnvFrom -}}
-            {{- toYaml .Values.catalog.extraEnvFrom | nindent 12 }}
+            {{- tpl (toYaml .Values.catalog.extraEnvFrom) . | nindent 12 }}
             {{- end }}
           ports:
             - name: http
@@ -190,11 +190,11 @@ spec:
             {{- end }}
           {{- end }}
           {{- with .Values.OPABridge.extraEnv }}
-            {{- toYaml . | nindent 12 }}
+            {{- tpl (toYaml .) $ | nindent 12 }}
           {{- end }}
           {{- if .Values.OPABridge.extraEnvFrom }}
           envFrom:
-            {{- toYaml .Values.OPABridge.extraEnvFrom | nindent 12 }}
+            {{- tpl (toYaml .Values.OPABridge.extraEnvFrom) . | nindent 12 }}
           {{- end }}
           args:
             - "run"

--- a/charts/lakekeeper/templates/db-migration.yaml
+++ b/charts/lakekeeper/templates/db-migration.yaml
@@ -76,7 +76,7 @@ spec:
           envFrom:
             {{- include "iceberg-catalog.envFrom" . | indent 12 }}
             {{- if .Values.catalog.extraEnvFrom -}}
-            {{- toYaml .Values.catalog.extraEnvFrom | nindent 12 }}
+            {{- tpl (toYaml .Values.catalog.extraEnvFrom) . | nindent 12 }}
             {{- end }}
           {{- if .Values.catalog.command }}
           command:


### PR DESCRIPTION
Hello, I have been using your lakekeeper chart to deploy my lakekeeper in my local kubernetes cluster, but I have noticed a small problem that I cannot provide dynamic templated values from my values because of some missing `tpl` calls. I think this patch could be helpful for everybody consuming this chart. Let me know if it is good enough :) 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Helm template processing to support dynamic expressions in user-defined environment variable configurations (`extraEnv` and `extraEnvFrom`). Users can now leverage template interpolation for more flexible environment variable setup across deployment components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->