### PR TITLE
chore: Release 0.11.0 - bump Lakekeeper to 0.12.2, Plus 0.12.1

### DIFF
--- a/charts/lakekeeper/Changelog.md
+++ b/charts/lakekeeper/Changelog.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+## [0.11.0] - 2026-05-11
+
+### Changed
+* Update OPA docker tag to v1.16.1
+
+### Added
+* Render `catalog.extraEnv`, `catalog.extraEnvFrom`, `OPABridge.extraEnv` and `OPABridge.extraEnvFrom` through `tpl` so values can reference other chart values / templates
+
 ### Fixed
 
 ## [0.10.1] - 2026-04-05

--- a/charts/lakekeeper/Chart.yaml
+++ b/charts/lakekeeper/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: lakekeeper
 description: Helm Chart for Lakekeeper - a rust native Iceberg Rest Catalog
-version: 0.10.1
-appVersion: 0.12.0
+version: 0.11.0
+appVersion: 0.12.2
 type: application
 home: https://github.com/lakekeeper/lakekeeper
 icon: https://raw.githubusercontent.com/lakekeeper/lakekeeper/refs/heads/main/site/docs/assets/bear.svg

--- a/charts/lakekeeper/templates/_helpers.tpl
+++ b/charts/lakekeeper/templates/_helpers.tpl
@@ -9,13 +9,13 @@
   {{- $repository = "quay.io/lakekeeper/catalog" -}}
 {{- end -}}
 {{- $tag := "" -}}
-{{- /* Default versions: enterprise=v0.11.3, community=v0.12.0 */ -}}
+{{- /* Default versions: enterprise=v0.12.1, community=v0.12.2 */ -}}
 {{- if .Values.catalog.image.tag -}}
   {{- $tag = .Values.catalog.image.tag -}}
 {{- else if $isPlus -}}
-  {{- $tag = "v0.11.3-distroless" -}}
+  {{- $tag = "v0.12.1-distroless" -}}
 {{- else -}}
-  {{- $tag = "v0.12.0" -}}
+  {{- $tag = "v0.12.2" -}}
 {{- end -}}
 {{- printf "%s:%s" $repository $tag -}}
 {{- end -}}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configuration parameters now support templating to reference other chart values.

* **Chores**
  * Upgraded OPA Docker image to v1.16.1.
  * Updated default container image tags for both standard and plus editions.
  * Bumped Helm chart version to 0.11.0 and application version to 0.12.2.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lakekeeper/lakekeeper-charts/pull/138)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->