### PR TITLE
chore(deps): update chart dependencies and CI tooling

### DIFF
--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -7,24 +7,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Set up Helm
-        uses: azure/setup-helm@v5.0.0
+        uses: azure/setup-helm@v5.0.1
         with:
-          version: v3.14.4
+          version: v3.21.2
 
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.12'
+          python-version: '3.14'
           check-latest: true
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.8.0
         with:
-            version: v3.10.1
+            version: v3.14.0
 
       - name: Add groundhog2k helm repo
         run: helm repo add groundhog2k https://groundhog2k.github.io/helm-charts/

--- a/.github/workflows/release-chart.yaml
+++ b/.github/workflows/release-chart.yaml
@@ -14,7 +14,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -24,9 +24,9 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v5.0.0
+        uses: azure/setup-helm@v5.0.1
         with:
-          version: v3.13.3
+          version: v3.21.2
 
       - name: Add Helm Dependency Repos
         run: |

--- a/charts/lakekeeper/Changelog.md
+++ b/charts/lakekeeper/Changelog.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+* Update OPA docker tag to v1.18.1
+* Update OpenFGA Chart to v0.3.10 / OpenFGA v1.18.1
+* Update Postgres Chart to v1.6.4, Postgres 18.4
+  * ⚠️ Major Postgres version bump (17 -> 18). There is **no automatic data migration**: PostgreSQL 18 will not start on a data directory created by PostgreSQL 17 without a manual `pg_upgrade`. The embedded Postgres is intended for testing only — use an external Postgres for production.
 
 ### Added
 

--- a/charts/lakekeeper/Chart.yaml
+++ b/charts/lakekeeper/Chart.yaml
@@ -17,12 +17,12 @@ keywords:
   - lakehouse
 dependencies:
   - name: postgres
-    version: 1.5.13
+    version: 1.6.4
     repository: https://groundhog2k.github.io/helm-charts/
     condition: postgresql.enabled
     alias: postgresql
   - name: openfga
-    version: 0.2.62
+    version: 0.3.10
     repository: https://openfga.github.io/helm-charts
     condition: internalOpenFGA
     alias: openfga

--- a/charts/lakekeeper/values.yaml
+++ b/charts/lakekeeper/values.yaml
@@ -637,7 +637,7 @@ OPABridge:
     # -- The image repository to pull from
     repository: openpolicyagent/opa
     # -- The image tag to pull
-    tag: 1.16.1
+    tag: 1.18.1
     # -- The image pull policy
     pullPolicy: IfNotPresent
     # -- User ID for the OPA container. Any non-zero number works with


### PR DESCRIPTION
Chart content (recorded in Changelog under [Unreleased]):
* OPA image tag 1.16.1 -> 1.18.1
* OpenFGA subchart 0.2.62 -> 0.3.10 (OpenFGA v1.18.1)
* Postgres subchart 1.5.13 -> 1.6.4 (Postgres 18.4; embedded DB only, major bump 17 -> 18 with no auto-migration)

CI tooling:
* actions/checkout v6 -> v7
* azure/setup-helm v5.0.0 -> v5.0.1
* helm CLI v3.14.4/v3.13.3 -> v3.21.2
* chart-testing v3.10.1 -> v3.14.0
* python 3.12 -> 3.14